### PR TITLE
Bugfix/nanandref

### DIFF
--- a/SeeSharp/Experiments/Benchmark.cs
+++ b/SeeSharp/Experiments/Benchmark.cs
@@ -73,7 +73,7 @@ public class Benchmark
         {
             string refFilename = Path.Join(dir, "Reference.exr");
             reference.Value.File.CopyTo(refFilename, true);
-            refImg = new RgbImage(refFilename);
+            refImg = reference.Value.Image;
 
             try
             {
@@ -102,8 +102,7 @@ public class Benchmark
             method.Integrator.MaxDepth = sceneConfig.MaxDepth;
             method.Integrator.MinDepth = sceneConfig.MinDepth;
 
-            if (computeErrorMetrics && refImg != null)
-                scene.FrameBuffer.ReferenceImage = refImg;
+            scene.FrameBuffer.ReferenceImage = computeErrorMetrics ? refImg : null;
 
             scene.Raytracer.ResetStats();
             ShadingStatCounter.Reset();

--- a/SeeSharp/Experiments/Benchmark.cs
+++ b/SeeSharp/Experiments/Benchmark.cs
@@ -73,6 +73,7 @@ public class Benchmark
         {
             string refFilename = Path.Join(dir, "Reference.exr");
             reference.Value.File.CopyTo(refFilename, true);
+            refImg = new RgbImage(refFilename);
 
             try
             {

--- a/SeeSharp/Images/FrameBuffer.cs
+++ b/SeeSharp/Images/FrameBuffer.cs
@@ -420,8 +420,11 @@ public class FrameBuffer : IDisposable
             .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             .InformationalVersion;
 
-        // Write the metadata as json
-        string json = JsonSerializer.Serialize(MetaData, options: new() { WriteIndented = true });
+        string json = JsonSerializer.Serialize(MetaData, options: new()
+        {
+            WriteIndented = true,
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
+        });
         File.WriteAllText(basename + ".json", json);
     }
 


### PR DESCRIPTION
Allow NaNs inside the exported JSONs,
and fix a reference loading for convergence tracking.