### PR TITLE
Fix background MIS, `NumShadowRays != 1` and some few other tweaks

### DIFF
--- a/SeeSharp/Geometry/SurfacePoint.cs
+++ b/SeeSharp/Geometry/SurfacePoint.cs
@@ -4,41 +4,70 @@
 /// Represents a point on the surface of a mesh in the scene. Wrapper around <see cref="Hit"/> with
 /// additional SeeSharp specific material information.
 /// </summary>
-public struct SurfacePoint {
+public struct SurfacePoint
+{
     /// <summary>
     /// Position in world space
     /// </summary>
-    public Vector3 Position { get => hit.Position; set => hit.Position = value; }
+    public Vector3 Position
+    {
+        get => hit.Position;
+        set => hit.Position = value;
+    }
 
     /// <summary>
     /// Face normal at the point (i.e., actual geometric normal, not the shading normal)
     /// </summary>
-    public Vector3 Normal { get => hit.Normal; set => hit.Normal = value; }
+    public Vector3 Normal
+    {
+        get => hit.Normal;
+        set => hit.Normal = value;
+    }
 
     /// <summary>
     /// Barycentric coordinates within the primitive
     /// </summary>
-    public Vector2 BarycentricCoords { get => hit.BarycentricCoords; set => hit.BarycentricCoords = value; }
+    public Vector2 BarycentricCoords
+    {
+        get => hit.BarycentricCoords;
+        set => hit.BarycentricCoords = value;
+    }
 
     /// <summary>
     /// The mesh on which this point lies
     /// </summary>
-    public Mesh Mesh { get => hit.Mesh as Mesh; set => hit.Mesh = value; }
+    public Mesh Mesh
+    {
+        get => hit.Mesh as Mesh;
+        set => hit.Mesh = value;
+    }
 
     /// <summary>
     /// Index of the primitive within the mesh
     /// </summary>
-    public uint PrimId { get => hit.PrimId; set => hit.PrimId = value; }
+    public uint PrimId
+    {
+        get => hit.PrimId;
+        set => hit.PrimId = value;
+    }
 
     /// <summary>
     /// Offset that should be used to avoid self-intersection during ray tracing
     /// </summary>
-    public float ErrorOffset { get => hit.ErrorOffset; set => hit.ErrorOffset = value; }
+    public float ErrorOffset
+    {
+        get => hit.ErrorOffset;
+        set => hit.ErrorOffset = value;
+    }
 
     /// <summary>
     /// Distance from a previous point if this is a ray intersection
     /// </summary>
-    public float Distance { get => hit.Distance; set => hit.Distance = value; }
+    public float Distance
+    {
+        get => hit.Distance;
+        set => hit.Distance = value;
+    }
 
     /// <summary>
     /// Checks if the point is valid
@@ -54,7 +83,8 @@ public struct SurfacePoint {
     /// Implicit cast from a TinyEmbree hit object for convenience
     /// </summary>
     /// <param name="hit"></param>
-    public static implicit operator SurfacePoint(Hit hit) {
+    public static implicit operator SurfacePoint(Hit hit)
+    {
         return new SurfacePoint { hit = hit };
     }
 
@@ -72,6 +102,8 @@ public struct SurfacePoint {
     /// The material of the intersected mesh
     /// </summary>
     public Material Material => Mesh.Material;
+
+    public static SurfacePoint Invalid => new() { Mesh = null };
 
     Hit hit;
 }

--- a/SeeSharp/Integrators/Bidir/BidirBase.Camera.cs
+++ b/SeeSharp/Integrators/Bidir/BidirBase.Camera.cs
@@ -537,8 +537,8 @@ public abstract partial class BidirBase<CameraPayloadType> {
         float pdfEmit = ComputeBackgroundPdf(ray.Origin, -ray.Direction);
 
         // Compute the pdf of sampling the same connection via next event estimation.
-        float pdfNextEvent = NextEventPdf(new SurfacePoint { Position = ray.Origin },
-                                          new SurfacePoint { Position = ray.Origin + ray.Direction });
+        // TODO get the actual previous point (need the mesh, not just the position)
+        float pdfNextEvent = NextEventPdf(new SurfacePoint(), SurfacePoint.Invalid);
 
         int numPdfs = path.Vertices.Count;
         int lastCameraVertexIdx = numPdfs - 1;

--- a/SeeSharp/Integrators/Bidir/BidirBase.Camera.cs
+++ b/SeeSharp/Integrators/Bidir/BidirBase.Camera.cs
@@ -336,6 +336,9 @@ public abstract partial class BidirBase<CameraPayloadType> {
     /// <param name="to">The point on the light source</param>
     /// <returns>PDF of next event estimation</returns>
     public virtual float NextEventPdf(SurfacePoint from, SurfacePoint to) {
+        // Switch to background case if "to" is a position in free space, not on a mesh
+        if (!to) return NextEventPdf(from, to.Position - from.Position);
+
         float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
         var emitter = Scene.QueryEmitter(to);
         return emitter.PdfUniformArea(to) * SelectLightPmf(from, emitter) * (1 - backgroundProbability) * NumShadowRays;

--- a/SeeSharp/Integrators/Bidir/BidirBase.Camera.cs
+++ b/SeeSharp/Integrators/Bidir/BidirBase.Camera.cs
@@ -325,7 +325,7 @@ public abstract partial class BidirBase<CameraPayloadType> {
     protected virtual (Emitter, SurfaceSample) SampleNextEvent(SurfacePoint from, ref RNG rng) {
         var (light, lightProb) = SelectLight(from, ref rng);
         var lightSample = light.SampleUniformArea(rng.NextFloat2D());
-        lightSample.Pdf *= lightProb;
+        lightSample.Pdf *= lightProb * NumShadowRays;
         return (light, lightSample);
     }
 
@@ -339,10 +339,10 @@ public abstract partial class BidirBase<CameraPayloadType> {
         float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
         if (to.Mesh == null) { // Background
             var direction = to.Position - from.Position;
-            return Scene.Background.DirectionPdf(direction) * backgroundProbability;
+            return Scene.Background.DirectionPdf(direction) * backgroundProbability * NumShadowRays;
         } else { // Emissive object
             var emitter = Scene.QueryEmitter(to);
-            return emitter.PdfUniformArea(to) * SelectLightPmf(from, emitter) * (1 - backgroundProbability);
+            return emitter.PdfUniformArea(to) * SelectLightPmf(from, emitter) * (1 - backgroundProbability) * NumShadowRays;
         }
     }
 
@@ -383,8 +383,8 @@ public abstract partial class BidirBase<CameraPayloadType> {
                 return RgbColor.Black; // There is no background
 
             var sample = Scene.Background.SampleDirection(rng.NextFloat2D());
-            sample.Pdf *= backgroundProbability;
-            sample.Weight /= backgroundProbability;
+            sample.Pdf *= backgroundProbability * NumShadowRays;
+            sample.Weight /= backgroundProbability * NumShadowRays;
 
             if (sample.Pdf == 0) // Prevent NaN
                 return RgbColor.Black;
@@ -536,10 +536,9 @@ public abstract partial class BidirBase<CameraPayloadType> {
         // Compute the pdf of sampling the previous point by emission from the background
         float pdfEmit = ComputeBackgroundPdf(ray.Origin, -ray.Direction);
 
-        // Compute the pdf of sampling the same connection via next event estimation
-        float pdfNextEvent = Scene.Background.DirectionPdf(ray.Direction);
-        float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
-        pdfNextEvent *= backgroundProbability;
+        // Compute the pdf of sampling the same connection via next event estimation.
+        float pdfNextEvent = NextEventPdf(new SurfacePoint { Position = ray.Origin },
+                                          new SurfacePoint { Position = ray.Origin + ray.Direction });
 
         int numPdfs = path.Vertices.Count;
         int lastCameraVertexIdx = numPdfs - 1;

--- a/SeeSharp/Integrators/Bidir/BidirBase.Camera.cs
+++ b/SeeSharp/Integrators/Bidir/BidirBase.Camera.cs
@@ -330,20 +330,26 @@ public abstract partial class BidirBase<CameraPayloadType> {
     }
 
     /// <summary>
-    /// Computes the pdf used by <see cref="SampleNextEvent" />
+    /// Computes the pdf used by <see cref="SampleNextEvent" /> for an area light source. Assumes that `to` is a valid point on an emitter.
     /// </summary>
     /// <param name="from">The shading point</param>
     /// <param name="to">The point on the light source</param>
     /// <returns>PDF of next event estimation</returns>
-    protected virtual float NextEventPdf(SurfacePoint from, SurfacePoint to) {
+    public virtual float NextEventPdf(SurfacePoint from, SurfacePoint to) {
         float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
-        if (to.Mesh == null) { // Background
-            var direction = to.Position - from.Position;
-            return Scene.Background.DirectionPdf(direction) * backgroundProbability * NumShadowRays;
-        } else { // Emissive object
-            var emitter = Scene.QueryEmitter(to);
-            return emitter.PdfUniformArea(to) * SelectLightPmf(from, emitter) * (1 - backgroundProbability) * NumShadowRays;
-        }
+        var emitter = Scene.QueryEmitter(to);
+        return emitter.PdfUniformArea(to) * SelectLightPmf(from, emitter) * (1 - backgroundProbability) * NumShadowRays;
+    }
+
+    /// <summary>
+    /// Computes the pdf used by <see cref="SampleNextEvent" /> for a background ray direction. 
+    /// </summary>
+    /// <param name="from">The shading point</param>
+    /// <param name="direction">The direction from the shading point to the background</param>
+    /// <returns>PDF of next event estimation</returns>
+    public virtual float NextEventPdf(SurfacePoint from, Vector3 direction) {
+        float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
+        return Scene.Background.DirectionPdf(direction) * backgroundProbability * NumShadowRays;
     }
 
     /// <summary>
@@ -503,7 +509,7 @@ public abstract partial class BidirBase<CameraPayloadType> {
 
         // Compute pdf values
         float pdfEmit = ComputeEmitterPdf(emitter, hit, outDir, reversePdfJacobian);
-        float pdfNextEvent = NextEventPdf(new SurfacePoint(), hit); // TODO get the actual previous point!
+        float pdfNextEvent = NextEventPdf(SurfacePoint.Invalid, hit); // TODO get the actual previous point!
 
         int numPdfs = path.Vertices.Count;
         int lastCameraVertexIdx = numPdfs - 1;
@@ -538,7 +544,7 @@ public abstract partial class BidirBase<CameraPayloadType> {
 
         // Compute the pdf of sampling the same connection via next event estimation.
         // TODO get the actual previous point (need the mesh, not just the position)
-        float pdfNextEvent = NextEventPdf(new SurfacePoint(), SurfacePoint.Invalid);
+        float pdfNextEvent = NextEventPdf(SurfacePoint.Invalid, ray.Direction);
 
         int numPdfs = path.Vertices.Count;
         int lastCameraVertexIdx = numPdfs - 1;

--- a/SeeSharp/Integrators/Bidir/BidirBase.Light.cs
+++ b/SeeSharp/Integrators/Bidir/BidirBase.Light.cs
@@ -74,7 +74,9 @@ public abstract partial class BidirBase<CameraPayloadType> {
         pathPdfs.PdfsCameraToLight[0] = response.PdfEmit;
         pathPdfs.PdfsCameraToLight[1] = pdfReverse;
         if (vertex.Depth == 1)
-            pathPdfs.PdfNextEvent = NextEventPdf(vertex.Point, ancestor.Point);
+            pathPdfs.PdfNextEvent = ancestor.Point 
+                ? NextEventPdf(vertex.Point, ancestor.Point) 
+                : NextEventPdf(vertex.Point, ancestor.Point.Position - vertex.Point.Position);
 
         float misWeight = LightTracerMis(vertex, pathPdfs, response.Pixel, distToCam);
 
@@ -201,7 +203,7 @@ public abstract partial class BidirBase<CameraPayloadType> {
         else
             PathCache.Clear();
 
-        LightPathWalk walkModifier = new(PathCache, (to, from, _) => NextEventPdf(from, to));
+        LightPathWalk walkModifier = new(PathCache, (to, from, _) => to ? NextEventPdf(from, to) : NextEventPdf(from, to.Position - from.Position));
 
         Parallel.For(0, NumLightPaths, idx => {
             var rng = new RNG(seed, (uint)idx, iter);

--- a/SeeSharp/Integrators/Bidir/BidirBase.cs
+++ b/SeeSharp/Integrators/Bidir/BidirBase.cs
@@ -22,6 +22,12 @@ public abstract partial class BidirBase<CameraPayloadType> : Integrator
     public int NumLightPaths { get; set; } = -1;
 
     /// <summary>
+    /// Number of shadow rays (next event estimation samples) per camera vertex. Zero disables the technique. 
+    /// Must only be changed in-between rendering iterations. Otherwise: mayhem.
+    /// </summary>
+    public int NumShadowRays = 1;
+
+    /// <summary>
     /// The base seed to generate camera paths.
     /// </summary>
     public uint BaseSeedCamera

--- a/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
+++ b/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
@@ -503,6 +503,9 @@ public class CameraStoringVCM<TLightPathData> : Integrator where TLightPathData 
     /// <param name="to">The point on the light source</param>
     /// <returns>PDF of next event estimation</returns>
     public virtual float NextEventPdf(SurfacePoint from, SurfacePoint to) {
+        // Switch to background case if "to" is a position in free space, not on a mesh
+        if (!to) return NextEventPdf(from, to.Position - from.Position);
+
         float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
         var emitter = Scene.QueryEmitter(to);
         return emitter.PdfUniformArea(to) * SelectLightPmf(from, emitter) * (1 - backgroundProbability) * NumShadowRays;

--- a/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
+++ b/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
@@ -420,7 +420,7 @@ public class CameraStoringVCM<TLightPathData> : Integrator where TLightPathData 
         float pdfEmit = ComputeBackgroundPdf(ray.Origin, -ray.Direction);
 
         // Compute the pdf of sampling the same connection via next event estimation.
-        float pdfNextEvent = NextEventPdf(state.Vertices[^1].Point, SurfacePoint.Invalid);
+        float pdfNextEvent = NextEventPdf(state.Vertices[^1].Point, ray.Direction);
 
         var pathPdfs = new BidirPathPdfs(stackalloc float[state.Depth], stackalloc float[state.Depth]);
         pathPdfs.GatherCameraPdfs(state, state.Depth - 2);
@@ -497,20 +497,26 @@ public class CameraStoringVCM<TLightPathData> : Integrator where TLightPathData 
     }
 
     /// <summary>
-    /// Computes the pdf used by <see cref="SampleNextEvent" />
+    /// Computes the pdf used by <see cref="SampleNextEvent" /> for an area light source. Assumes that `to` is a valid point on an emitter.
     /// </summary>
     /// <param name="from">The shading point</param>
     /// <param name="to">The point on the light source</param>
     /// <returns>PDF of next event estimation</returns>
     public virtual float NextEventPdf(SurfacePoint from, SurfacePoint to) {
         float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
-        if (to.Mesh == null) { // Background
-            var direction = to.Position - from.Position;
-            return Scene.Background.DirectionPdf(direction) * backgroundProbability * NumShadowRays;
-        } else { // Emissive object
-            var emitter = Scene.QueryEmitter(to);
-            return emitter.PdfUniformArea(to) * SelectLightPmf(from, emitter) * (1 - backgroundProbability) * NumShadowRays;
-        }
+        var emitter = Scene.QueryEmitter(to);
+        return emitter.PdfUniformArea(to) * SelectLightPmf(from, emitter) * (1 - backgroundProbability) * NumShadowRays;
+    }
+
+    /// <summary>
+    /// Computes the pdf used by <see cref="SampleNextEvent" /> for a background ray direction. 
+    /// </summary>
+    /// <param name="from">The shading point</param>
+    /// <param name="direction">The direction from the shading point to the background</param>
+    /// <returns>PDF of next event estimation</returns>
+    public virtual float NextEventPdf(SurfacePoint from, Vector3 direction) {
+        float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
+        return Scene.Background.DirectionPdf(direction) * backgroundProbability * NumShadowRays;
     }
 
     /// <summary>

--- a/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
+++ b/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
@@ -420,8 +420,7 @@ public class CameraStoringVCM<TLightPathData> : Integrator where TLightPathData 
         float pdfEmit = ComputeBackgroundPdf(ray.Origin, -ray.Direction);
 
         // Compute the pdf of sampling the same connection via next event estimation.
-        float pdfNextEvent = NextEventPdf(new SurfacePoint { Position = ray.Origin },
-                                          new SurfacePoint { Position = ray.Origin + ray.Direction });
+        float pdfNextEvent = NextEventPdf(state.Vertices[^1].Point, SurfacePoint.Invalid);
 
         var pathPdfs = new BidirPathPdfs(stackalloc float[state.Depth], stackalloc float[state.Depth]);
         pathPdfs.GatherCameraPdfs(state, state.Depth - 2);

--- a/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
+++ b/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
@@ -163,115 +163,121 @@ public class CameraStoringVCM<TLightPathData> : Integrator where TLightPathData 
 
     public override void Render(Scene scene) => Render(scene, 0);
 
-    public void Render(Scene scene, int startAtIteration) {
-        Scene = scene;
-        IsolatedPixel = null;
+    public void Render(Scene scene, int startAtIteration) 
+    {
+        try 
+        {
+            Scene = scene;
+            IsolatedPixel = null;
 
-        if (NumLightPaths < 0)
-            NumLightPaths = scene.FrameBuffer.Width * scene.FrameBuffer.Height;
+            if (NumLightPaths < 0)
+                NumLightPaths = scene.FrameBuffer.Width * scene.FrameBuffer.Height;
 
-        if (EnableDenoiser)
-            DenoiseBuffers = new(scene.FrameBuffer);
+            if (EnableDenoiser)
+                DenoiseBuffers = new(scene.FrameBuffer);
 
-        OnBeforeRender();
+            OnBeforeRender();
 
-        if (RenderTechniquePyramid && MaxDepth > 10) {
-            Logger.Warning("MaxDepth is set above 10, but a technique pyramid was requested (RenderTechniquePyramid == true). To avoid excessive memory consumption, the RenderTechniquePyramid flag will be ignored.");
-            RenderTechniquePyramid = false;
-        }
-
-        if (RenderTechniquePyramid) {
-            TechPyramidRaw = new TechPyramid(scene.FrameBuffer.Width, scene.FrameBuffer.Height,
-                                             minDepth: 1, maxDepth: MaxDepth, merges: EnableMerging);
-            TechPyramidWeighted = new TechPyramid(scene.FrameBuffer.Width, scene.FrameBuffer.Height,
-                                                  minDepth: 1, maxDepth: MaxDepth, merges: EnableMerging);
-        }
-
-        CameraPaths = new(scene.FrameBuffer.Width * scene.FrameBuffer.Height, Math.Min(MaxDepth + 1, 10));
-        photonMap ??= new();
-
-        ProgressBar progressBar = new(prefix: "Rendering...");
-        progressBar.Start(NumIterations);
-        RenderTimer timer = new();
-        Stopwatch lightTracerTimer = new();
-        Stopwatch pathTracerTimer = new();
-        Stopwatch accelBuildTimer = new();
-        ShadingStatCounter.Reset();
-        scene.Raytracer.ResetStats();
-        for (uint iter = (uint)startAtIteration; iter - startAtIteration < NumIterations; ++iter) {
-            long nextIterTime = timer.RenderTime + timer.PerIterationCost;
-            if (MaximumRenderTimeMs.HasValue && nextIterTime > MaximumRenderTimeMs.Value) {
-                Logger.Log("Maximum render time exhausted.");
-                // if (EnableDenoiser) DenoiseBuffers.Denoise();
-                progressBar.Terminate();
-                break;
+            if (RenderTechniquePyramid && MaxDepth > 10) {
+                Logger.Warning("MaxDepth is set above 10, but a technique pyramid was requested (RenderTechniquePyramid == true). To avoid excessive memory consumption, the RenderTechniquePyramid flag will be ignored.");
+                RenderTechniquePyramid = false;
             }
 
-            timer.StartIteration();
-
-            scene.FrameBuffer.StartIteration();
-            timer.EndFrameBuffer();
-
-            OnStartIteration(iter);
-            try {
-                pathTracerTimer.Start();
-                Parallel.For(0, Scene.FrameBuffer.Height, row => {
-                    for (uint col = 0; col < Scene.FrameBuffer.Width; ++col) {
-                        uint pixelIndex = (uint)(row * Scene.FrameBuffer.Width + col);
-                        var rng = new RNG(BaseSeedCamera, pixelIndex, iter);
-                        TraceCameraPath((uint)row, col, ref rng);
-                    }
-                });
-                pathTracerTimer.Stop();
-
-                accelBuildTimer.Start();
-                if (EnableMerging)
-                    BuildImportonAccel();
-                accelBuildTimer.Stop();
-
-                lightTracerTimer.Start();
-                TraceLightPaths(iter);
-                lightTracerTimer.Stop();
-            } catch {
-                Logger.Log($"Exception in iteration {iter} out of {NumIterations}.", Verbosity.Error);
-                throw;
+            if (RenderTechniquePyramid) {
+                TechPyramidRaw = new TechPyramid(scene.FrameBuffer.Width, scene.FrameBuffer.Height,
+                                                 minDepth: 1, maxDepth: MaxDepth, merges: EnableMerging);
+                TechPyramidWeighted = new TechPyramid(scene.FrameBuffer.Width, scene.FrameBuffer.Height,
+                                                      minDepth: 1, maxDepth: MaxDepth, merges: EnableMerging);
             }
-            OnEndIteration(iter);
-            CameraPaths.Clear();
-            timer.EndRender();
 
-            // if (iter == NumIterations - 1 && EnableDenoiser)
-            //     DenoiseBuffers.Denoise();
+            CameraPaths = new(scene.FrameBuffer.Width * scene.FrameBuffer.Height, Math.Min(MaxDepth + 1, 10));
+            photonMap ??= new();
 
-            scene.FrameBuffer.EndIteration();
-            timer.EndFrameBuffer();
+            ProgressBar progressBar = new(prefix: "Rendering...");
+            progressBar.Start(NumIterations);
+            RenderTimer timer = new();
+            Stopwatch lightTracerTimer = new();
+            Stopwatch pathTracerTimer = new();
+            Stopwatch accelBuildTimer = new();
+            ShadingStatCounter.Reset();
+            scene.Raytracer.ResetStats();
+            for (uint iter = (uint)startAtIteration; iter - startAtIteration < NumIterations; ++iter) {
+                long nextIterTime = timer.RenderTime + timer.PerIterationCost;
+                if (MaximumRenderTimeMs.HasValue && nextIterTime > MaximumRenderTimeMs.Value) {
+                    Logger.Log("Maximum render time exhausted.");
+                    // if (EnableDenoiser) DenoiseBuffers.Denoise();
+                    progressBar.Terminate();
+                    break;
+                }
 
-            progressBar.ReportDone(1);
-            timer.EndIteration();
+                timer.StartIteration();
+
+                scene.FrameBuffer.StartIteration();
+                timer.EndFrameBuffer();
+
+                OnStartIteration(iter);
+                try {
+                    pathTracerTimer.Start();
+                    Parallel.For(0, Scene.FrameBuffer.Height, row => {
+                        for (uint col = 0; col < Scene.FrameBuffer.Width; ++col) {
+                            uint pixelIndex = (uint)(row * Scene.FrameBuffer.Width + col);
+                            var rng = new RNG(BaseSeedCamera, pixelIndex, iter);
+                            TraceCameraPath((uint)row, col, ref rng);
+                        }
+                    });
+                    pathTracerTimer.Stop();
+
+                    accelBuildTimer.Start();
+                    if (EnableMerging)
+                        BuildImportonAccel();
+                    accelBuildTimer.Stop();
+
+                    lightTracerTimer.Start();
+                    TraceLightPaths(iter);
+                    lightTracerTimer.Stop();
+                } catch {
+                    Logger.Log($"Exception in iteration {iter} out of {NumIterations}.", Verbosity.Error);
+                    throw;
+                }
+                OnEndIteration(iter);
+                CameraPaths.Clear();
+                timer.EndRender();
+
+                // if (iter == NumIterations - 1 && EnableDenoiser)
+                //     DenoiseBuffers.Denoise();
+
+                scene.FrameBuffer.EndIteration();
+                timer.EndFrameBuffer();
+
+                progressBar.ReportDone(1);
+                timer.EndIteration();
+            }
+
+            scene.FrameBuffer.MetaData["RenderTime"] = timer.RenderTime;
+            scene.FrameBuffer.MetaData["FrameBufferTime"] = timer.FrameBufferTime;
+            scene.FrameBuffer.MetaData["PathTracerTime"] = pathTracerTimer.ElapsedMilliseconds;
+            scene.FrameBuffer.MetaData["LightTracerTime"] = lightTracerTimer.ElapsedMilliseconds;
+            scene.FrameBuffer.MetaData["ShadingStats"] = ShadingStatCounter.Current;
+            scene.FrameBuffer.MetaData["RayTracerStats"] = scene.Raytracer.Stats;
+            scene.FrameBuffer.MetaData["BaseSeed"] = BaseSeed;
+
+            OnAfterRender();
+
+            if (RenderTechniquePyramid) {
+                TechPyramidRaw.Normalize(1.0f / Scene.FrameBuffer.CurIteration);
+                if (!string.IsNullOrEmpty(scene.FrameBuffer.Basename))
+                    TechPyramidRaw.WriteToFiles(Path.Join(scene.FrameBuffer.Basename, "techs-raw"));
+
+                TechPyramidWeighted.Normalize(1.0f / Scene.FrameBuffer.CurIteration);
+                if (!string.IsNullOrEmpty(scene.FrameBuffer.Basename))
+                    TechPyramidWeighted.WriteToFiles(Path.Join(scene.FrameBuffer.Basename, "techs-weighted"));
+            }
         }
-
-        scene.FrameBuffer.MetaData["RenderTime"] = timer.RenderTime;
-        scene.FrameBuffer.MetaData["FrameBufferTime"] = timer.FrameBufferTime;
-        scene.FrameBuffer.MetaData["PathTracerTime"] = pathTracerTimer.ElapsedMilliseconds;
-        scene.FrameBuffer.MetaData["LightTracerTime"] = lightTracerTimer.ElapsedMilliseconds;
-        scene.FrameBuffer.MetaData["ShadingStats"] = ShadingStatCounter.Current;
-        scene.FrameBuffer.MetaData["RayTracerStats"] = scene.Raytracer.Stats;
-        scene.FrameBuffer.MetaData["BaseSeed"] = BaseSeed;
-
-        OnAfterRender();
-
-        if (RenderTechniquePyramid) {
-            TechPyramidRaw.Normalize(1.0f / Scene.FrameBuffer.CurIteration);
-            if (!string.IsNullOrEmpty(scene.FrameBuffer.Basename))
-                TechPyramidRaw.WriteToFiles(Path.Join(scene.FrameBuffer.Basename, "techs-raw"));
-
-            TechPyramidWeighted.Normalize(1.0f / Scene.FrameBuffer.CurIteration);
-            if (!string.IsNullOrEmpty(scene.FrameBuffer.Basename))
-                TechPyramidWeighted.WriteToFiles(Path.Join(scene.FrameBuffer.Basename, "techs-weighted"));
+        finally
+        {
+            photonMap?.Dispose();
+            photonMap = null;
         }
-
-        photonMap.Dispose();
-        photonMap = null;
     }
 
     /// <summary>

--- a/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
+++ b/SeeSharp/Integrators/Bidir/CameraStoringVCM.cs
@@ -413,10 +413,9 @@ public class CameraStoringVCM<TLightPathData> : Integrator where TLightPathData 
         // Compute the pdf of sampling the previous point by emission from the background
         float pdfEmit = ComputeBackgroundPdf(ray.Origin, -ray.Direction);
 
-        // Compute the pdf of sampling the same connection via next event estimation
-        float pdfNextEvent = Scene.Background.DirectionPdf(ray.Direction);
-        float backgroundProbability = ComputeNextEventBackgroundProbability(/*hit*/);
-        pdfNextEvent *= backgroundProbability;
+        // Compute the pdf of sampling the same connection via next event estimation.
+        float pdfNextEvent = NextEventPdf(new SurfacePoint { Position = ray.Origin },
+                                          new SurfacePoint { Position = ray.Origin + ray.Direction });
 
         var pathPdfs = new BidirPathPdfs(stackalloc float[state.Depth], stackalloc float[state.Depth]);
         pathPdfs.GatherCameraPdfs(state, state.Depth - 2);
@@ -539,8 +538,8 @@ public class CameraStoringVCM<TLightPathData> : Integrator where TLightPathData 
                 return RgbColor.Black; // There is no background
 
             var sample = Scene.Background.SampleDirection(state.Rng.NextFloat2D());
-            sample.Pdf *= backgroundProbability;
-            sample.Weight /= backgroundProbability;
+            sample.Pdf *= backgroundProbability * NumShadowRays;
+            sample.Weight /= backgroundProbability * NumShadowRays;
 
             if (sample.Pdf == 0) // Prevent NaN
                 return RgbColor.Black;

--- a/SeeSharp/Integrators/Bidir/ClassicBidir.cs
+++ b/SeeSharp/Integrators/Bidir/ClassicBidir.cs
@@ -29,26 +29,8 @@ public class ClassicBidirBase<CameraPayloadType> : BidirBase<CameraPayloadType> 
     /// </summary>
     public bool EnableLightTracer = true;
 
-    /// <summary>
-    /// Number of shadow rays to use for next event estimation along the camera path. If set to zero,
-    /// no next event estimation is performed.
-    /// </summary>
-    public int NumShadowRays = 1;
-
     TechPyramid techPyramidRaw;
     TechPyramid techPyramidWeighted;
-
-    /// <inheritdoc />
-    protected override float NextEventPdf(SurfacePoint from, SurfacePoint to) {
-        return base.NextEventPdf(from, to) * NumShadowRays;
-    }
-
-    /// <inheritdoc />
-    protected override (Emitter, SurfaceSample) SampleNextEvent(SurfacePoint from, ref RNG rng) {
-        var (light, sample) = base.SampleNextEvent(from, ref rng);
-        sample.Pdf *= NumShadowRays;
-        return (light, sample);
-    }
 
     /// <inheritdoc />
     protected override void RegisterSample(RgbColor weight, float misWeight, Pixel pixel,

--- a/SeeSharp/Integrators/Bidir/VertexCacheBidir.cs
+++ b/SeeSharp/Integrators/Bidir/VertexCacheBidir.cs
@@ -19,11 +19,6 @@ public class VertexCacheBidirBase<CameraPayloadType> : BidirBase<CameraPayloadTy
     public int NumConnections = 1;
 
     /// <summary>
-    /// Number of shadow rays to use for next event. Disabled if zero.
-    /// </summary>
-    public int NumShadowRays = 1;
-
-    /// <summary>
     /// Set to false to disable connections between light vertices and the camera
     /// </summary>
     public bool EnableLightTracer = true;
@@ -46,18 +41,6 @@ public class VertexCacheBidirBase<CameraPayloadType> : BidirBase<CameraPayloadTy
     /// The light vertex resampler
     /// </summary>
     protected VertexSelector vertexSelector;
-
-    /// <inheritdoc />
-    protected override float NextEventPdf(SurfacePoint from, SurfacePoint to) {
-        return base.NextEventPdf(from, to) * NumShadowRays;
-    }
-
-    /// <inheritdoc />
-    protected override (Emitter, SurfaceSample) SampleNextEvent(SurfacePoint from, ref RNG rng) {
-        var (light, sample) = base.SampleNextEvent(from, ref rng);
-        sample.Pdf *= NumShadowRays;
-        return (light, sample);
-    }
 
     /// <inheritdoc />
     protected override (int, int, float) SelectBidirPath(SurfacePoint cameraPoint, Vector3 outDir,

--- a/SeeSharp/Integrators/Bidir/VertexConnectionAndMerging.cs
+++ b/SeeSharp/Integrators/Bidir/VertexConnectionAndMerging.cs
@@ -240,7 +240,17 @@ public class VertexConnectionAndMergingBase<CameraPayloadType>
         if (photonMap == null)
             photonMap = new();
 
-        base.Render(scene);
+        try
+        {
+            base.Render(scene);
+        }
+        catch
+        {
+            // Always dispose the photon map or memory might leak
+            photonMap.Dispose();
+            photonMap = null;
+            throw;
+        }
 
         // Store the technique pyramids
         if (RenderTechniquePyramid)

--- a/SeeSharp/Integrators/Bidir/VertexConnectionAndMerging.cs
+++ b/SeeSharp/Integrators/Bidir/VertexConnectionAndMerging.cs
@@ -244,12 +244,10 @@ public class VertexConnectionAndMergingBase<CameraPayloadType>
         {
             base.Render(scene);
         }
-        catch
+        finally
         {
-            // Always dispose the photon map or memory might leak
-            photonMap.Dispose();
+            photonMap?.Dispose();
             photonMap = null;
-            throw;
         }
 
         // Store the technique pyramids
@@ -267,9 +265,6 @@ public class VertexConnectionAndMergingBase<CameraPayloadType>
                     Path.Join(scene.FrameBuffer.Basename, "techs-weighted")
                 );
         }
-
-        photonMap.Dispose();
-        photonMap = null;
     }
 
     Stopwatch mergeBuildTimer;

--- a/SeeSharp/Integrators/PathTracer.cs
+++ b/SeeSharp/Integrators/PathTracer.cs
@@ -41,6 +41,13 @@ public class PathTracerBase<PayloadType> : Integrator {
     TechPyramid techPyramidRaw;
     TechPyramid techPyramidWeighted;
 
+    ThreadLocal<ulong> totalCamPathLen;
+
+    /// <summary>
+    /// Average number of camera path vertices per pixel, of the last finished iteration.
+    /// </summary>
+    public float AverageCameraPathLength { get; private set; }
+
     protected DenoiseBuffers denoiseBuffers;
 
     /// <summary>
@@ -220,6 +227,7 @@ public class PathTracerBase<PayloadType> : Integrator {
             scene.FrameBuffer.StartIteration();
             timer.EndFrameBuffer();
 
+            totalCamPathLen = new(true);
             OnPreIteration(sampleIndex);
             Parallel.For(0, scene.FrameBuffer.Height, row => {
                 for (uint col = 0; col < scene.FrameBuffer.Width; ++col) {
@@ -228,6 +236,9 @@ public class PathTracerBase<PayloadType> : Integrator {
                     RenderPixel((uint)row, col, ref rng, null);
                 }
             });
+            ulong totalVertices = 0;
+            foreach (ulong v in totalCamPathLen.Values) totalVertices += v;
+            AverageCameraPathLength = totalVertices / (float)(scene.FrameBuffer.Width * scene.FrameBuffer.Height);
             OnPostIteration(sampleIndex);
             timer.EndRender();
 
@@ -305,6 +316,7 @@ public class PathTracerBase<PayloadType> : Integrator {
 
     protected virtual RgbColor EstimateIncidentRadiance(Ray ray, ref PathState state, PathGraphNode graphVertex = null) {
         RgbColor radianceEstimate = RgbColor.Black;
+        ulong numVertices = 0;
 
         while (state.Depth <= MaxDepth) {
             var hit = scene.Raytracer.Trace(ray);
@@ -320,6 +332,7 @@ public class PathTracerBase<PayloadType> : Integrator {
                 break;
             }
 
+            numVertices++;
             OnHit(ray, hit, ref state);
 
             SurfaceShader shader = new(hit, -ray.Direction, false);
@@ -368,6 +381,8 @@ public class PathTracerBase<PayloadType> : Integrator {
             state.PreviousScatterWeight = bsdfSampleWeight / survivalProb;
             state.PreviousSurvivalProbability = survivalProb;
         }
+
+        totalCamPathLen?.Value += numVertices;
 
         return radianceEstimate;
     }


### PR DESCRIPTION
Handling of `NumShadowRays` is now in `BidirBase`. This fixes wrong pdf scaling when `NumShadowRays != 1`.

`NumShadowRays == 1` stays identical to previous results. Tests still fine.
All fixes are propagated to `CameraStoringVCM` as well.

Also includes:

- Dispose the photon map when rendering aborts on an exception (potential memory leak).
- Track the average camera path length in the path tracer as well.