### PR TITLE
expose the merge accel build timer to subclasses for per-iteration stage timing

### DIFF
--- a/SeeSharp/Integrators/Bidir/VertexConnectionAndMerging.cs
+++ b/SeeSharp/Integrators/Bidir/VertexConnectionAndMerging.cs
@@ -267,7 +267,8 @@ public class VertexConnectionAndMergingBase<CameraPayloadType>
         }
     }
 
-    Stopwatch mergeBuildTimer;
+    /// <summary>Accumulates the photon-map build time across iterations; reported as MergeAccelBuildTime.</summary>
+    protected Stopwatch mergeBuildTimer;
 
     /// <summary>
     /// Generates the acceleration structure for merging


### PR DESCRIPTION
Just add "protected" to mergeBuildTimer for subclasses to capture it - without using the metadata stuff (during run, not after).